### PR TITLE
use explicit functions for the stream and normal merge options

### DIFF
--- a/geojson-merge
+++ b/geojson-merge
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-var merge = require('./'),
+var geojsonMerge = require('./'),
+    stream = geojsonMerge.mergeFeatureCollectionStream,
+    merge = geojsonMerge.merge,
     fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2));
 
@@ -10,7 +12,7 @@ if (!argv._.length || argv.help) {
 }
 
 if (argv.s || argv.stream) {
-  merge(argv._, { stream: true }).pipe(process.stdout)
+  stream(argv._).pipe(process.stdout)
 } else {
   process.stdout.write(JSON.stringify(merge(argv._.map(function(n) {
       return JSON.parse(fs.readFileSync(n));


### PR DESCRIPTION
CLI throws the following error

```
/Users/jrousseau/npm/lib/node_modules/@mapbox/geojson-merge/geojson-merge:13
  merge(argv._, { stream: true }).pipe(process.stdout)
  ^

TypeError: merge is not a function
    at Object.<anonymous> (/Users/jrousseau/npm/lib/node_modules/@mapbox/geojson-merge/geojson-merge:13:3)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
    at node.js:966:3
```

It looks to be a symptom of #13 exporting two functions. This PR *should* fix the issue, given the `stream` option should be using the `mergeFeatureCollectionStream` function.

If you want me to make any changes, please let me know!