### PR TITLE
maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,22 @@ including FeatureCollection, Feature, and Geometry types.
 
 **Parameters**
 
--   `inputs` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** a list of GeoJSON objects of any type
+-   `inputs` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** a list of GeoJSON objects of any type
 
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** a geojson FeatureCollection.-   @example
-    var geojsonMerge = require('@mapbox/geojson-merge');var mergedStream = geojsonMerge.merge(\[
+**Examples**
+
+```javascript
+var geojsonMerge = require('@mapbox/geojson-merge');
+
+var mergedStream = geojsonMerge.merge([
   { type: 'Point', coordinates: [0, 1] },
   { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 1] }, properties: {} }
-]);mergedStream.pipe(process.stdout);
+]);
+
+mergedStream.pipe(process.stdout);
+```
+
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** a geojson FeatureCollection.
 
 ### mergeFeatureCollectionStream
 
@@ -41,7 +50,7 @@ larger than what you can keep in memory at one time.
 
 **Parameters**
 
--   `inputs` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** a list of filenames of GeoJSON files
+-   `inputs` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** a list of filenames of GeoJSON files
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ including FeatureCollection, Feature, and Geometry types.
 ```javascript
 var geojsonMerge = require('@mapbox/geojson-merge');
 
-var mergedStream = geojsonMerge.merge([
+var mergedGeoJSON = geojsonMerge.merge([
   { type: 'Point', coordinates: [0, 1] },
   { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 1] }, properties: {} }
 ]);
 
-mergedStream.pipe(process.stdout);
+console.log(JSON.stringify(mergedGeoJSON));
 ```
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** a geojson FeatureCollection.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var normalize = require('geojson-normalize');
+var normalize = require('@mapbox/geojson-normalize');
 var geojsonStream = require('geojson-stream');
 var fs = require('fs');
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var fs = require('fs');
  *
  * @param {Array<Object>} inputs a list of GeoJSON objects of any type
  * @return {Object} a geojson FeatureCollection.
- * * @example
+ * @example
  * var geojsonMerge = require('@mapbox/geojson-merge');
  *
  * var mergedStream = geojsonMerge.merge([

--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ var fs = require('fs');
  * @example
  * var geojsonMerge = require('@mapbox/geojson-merge');
  *
- * var mergedStream = geojsonMerge.merge([
+ * var mergedGeoJSON = geojsonMerge.merge([
  *   { type: 'Point', coordinates: [0, 1] },
  *   { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 1] }, properties: {} }
  * ]);
  *
- * mergedStream.pipe(process.stdout);
+ * console.log(JSON.stringify(mergedGeoJSON));
  */
 function merge (inputs) {
     var output = {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/mapbox/geojson-merge",
   "dependencies": {
+    "@mapbox/geojson-normalize": "^0.0.1",
     "geojson-fixtures": "~0.1.0",
-    "geojson-normalize": "0.0.0",
     "geojson-stream": "0.0.1",
     "minimist": "^1.2.0",
     "stream-concat": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "geojson-stream": "0.0.1",
     "minimist": "^1.2.0",
     "stream-concat": "0.1.0",
-    "tape": "~2.13.4"
+    "tape": "^4.9.0"
   },
   "devDependencies": {
     "concat-stream": "^1.6.0",


### PR DESCRIPTION
- geojson-normalize -> @mapbox/geojson-normalize
- update tape to fix install warning
- ensure merge example is generated in the README correctly
- fix merge example as it's not using streams