### PR TITLE
ADD: node-alpine container for cli tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:13.10.1-alpine
+COPY . /src/geojson-merge
+RUN npm install -g /src/geojson-merge
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/geojson-merge"]


### PR DESCRIPTION
This pull request adds a Dockerfile for the project. I wanted to use this tool but did not have node installed, so I created a container and used the CLI through Docker.

Build the Docker image:

```
cd geojson-merge  # enter project root directory
docker build --tag geojsonmerge .
```

Use the image:

```
docker run --rm -v /path/to/files:/work geojsonmerge a.geo.json b.geo.json > merged.geo.json
```